### PR TITLE
Do not use setup_postdata for obtaining reading time

### DIFF
--- a/loop-templates/article-track.php
+++ b/loop-templates/article-track.php
@@ -10,9 +10,8 @@ $track_related_posts = get_field('track_relationship', $id_post);
 
 // Reading time total
 $reading_time_array = array();
-foreach( $track_related_posts as $post ): 
-    setup_postdata($post);
-    $reading_time = get_field('reading-time');
+foreach( $track_related_posts as $related_post ):
+    $reading_time = get_field('reading-time', $related_post->ID);
     $reading_time_array[] = $reading_time;
 endforeach;
 $reading_time_total = array_sum($reading_time_array);


### PR DESCRIPTION
`setup_postdata` was being used for obtaning reading-time field data. This was replacing global $post and breaking the track content. We can just use a `$related_post` variable and send its ID as parameter for the `get_field` function.